### PR TITLE
Revert "Fix LocalTunnel Download"

### DIFF
--- a/Defs/Checks.py
+++ b/Defs/Checks.py
@@ -1,8 +1,8 @@
 import subprocess
 import ctypes
-from os import system, getuid, path
+from os import *
 from time import sleep
-import requests
+from urllib.request import urlopen, urlretrieve
 from platform import system as systemos, architecture
 from subprocess import check_output
 from Defs.Languages import *
@@ -16,13 +16,12 @@ languageSelector()
 def checkConnection(host='https://google.com'):  # Connection check
     system('clear')
     try:
-        req = requests.get(host, timeout=10)
-        if req.status_code == 200:
-            print("{0}HURRAY!! Internet is available.. We can Continue{1}".format(
-                GREEN, DEFAULT))
-            print("\n\n{0}Wait! Checking for Neccesary Packages{1}...\n ".format(
-                GREEN, DEFAULT))
-            return True
+        urlopen(host, timeout=10)
+        print("{0}HURRAY!! Internet is available.. We can Continue{1}".format(
+            GREEN, DEFAULT))
+        print("\n\n{0}Wait! Checking for Neccesary Packages{1}...\n ".format(
+            GREEN, DEFAULT))
+        return True
     except:
         return False
 
@@ -51,9 +50,7 @@ def checkNgrok():  # Ngrok check
             else:
                 filename = 'ngrok-stable-{0}-386.zip'.format(ostype)
         url = 'https://bin.equinox.io/c/4VmDzA7iaHb/' + filename
-        req = requests.get(url)
-        with open(filename, "wb") as file_obj:
-            file_obj.write(req.content)
+        urlretrieve(url, filename)
         system('unzip ' + filename)
         system('mv ngrok Server/ngrok')
         system('rm ' + filename)
@@ -73,9 +70,7 @@ def checkLocalxpose():  # Localxpose check
             else:
                 filename = 'loclx-linux-386.zip'.format(ostype)
         url = 'https://lxpdownloads.sgp1.digitaloceanspaces.com/cli/'+filename
-        req = requests.get(url)
-        with open("loclx-linux-download.zip", "wb") as file_obj:
-            file_obj.write(req.content)
+        urlretrieve(url, "loclx-linux-download.zip")
         system('unzip loclx-linux-download.zip && rm loclx-linux-download.zip')
         system('mv loclx-linux-* loclx && mv loclx Server/')
         system('clear')
@@ -86,9 +81,7 @@ def checkbinaryLT():  # LocalTunnel Binary File check.
         print('[*] LocalTunnel Binary File Not Found !!')
         print('[*] Downloading LocalTunnel...')
         url = "https://www.wa4e.com/downloads/lt-linux.zip"
-        req = requests.get(url)
-        with open("lt-linux.zip", "wb") as file_obj:
-            file_obj.write(req.content)
+        urlretrieve(url, "lt-linux.zip")
         system("unzip lt-linux.zip && rm lt-linux.zip")
         system("mv lt* lt && mv lt Server/lt ")
         system('clear')


### PR DESCRIPTION
Reverts DarkSecDevelopers/HiddenEye#446

- REVERTING DUE TO SOME ISSUES...
1) Their is no Onging Process Notifications about completion time during downloading of required packages.
2) Giving Errors During Downloading Of Localxpose Packages.