### PR TITLE
Stabilize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,4 @@
-
-Defs/__pycache__/
-
-Defs/ActionManager/__pycache__/
-
-Defs/ActionManager/Server/__pycache__/
-
-Defs/FeatureManager/__pycache__/
-
-Defs/FeatureManager/EmailManager/__pycache__/
-
-Defs/ImportManager/__pycache__/
-
-Defs/ThemeManager/__pycache__/
+*.pyc
 
 *.deb
 
@@ -33,12 +20,4 @@ Defs/FeatureManager/EmailManager/attachments/KeyloggerData.txt
 
 Server/CapturedData/KeyloggerData.txt
 
-Defs/LocalizationManager/__pycache__/
-
-Defs/LocalizationManager/lang_action_manager/__pycache__/
-
 eula.txt
-
-Defs/LocalizationManager/lang_action_manager/lang_server/__pycache__/
-
-Server/www/

--- a/Server/www/.gitignore
+++ b/Server/www/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
Two issues.

- One, multiple `__pycache__` dirs being ignore in .gitignore, but what we should be doing is ignoring `.pyc` files one time (which will do the same thing more broadly).
- Server/www is needed or the Python script fails fresh out of the box here, and I've seen several people report this as an issue. It's not documented anywhere that you need to do `mkdir Server/www` before the script is usable, so instead of requiring this, just commit an empty /Server/www directory and always ignore its contents.